### PR TITLE
fix: restart connection when forget wallet clicked

### DIFF
--- a/src/connector/observables/rtc-restart.ts
+++ b/src/connector/observables/rtc-restart.ts
@@ -1,12 +1,23 @@
 import log from 'loglevel'
-import { withLatestFrom, tap } from 'rxjs'
+import { withLatestFrom, tap, merge, filter } from 'rxjs'
 import { ConnectorSubscriptionsInput } from 'connector/_types'
 
 export const rtcRestart = (input: ConnectorSubscriptionsInput) => {
   const signalingSubjects = input.signalingServerClient.subjects
   const webRtcSubjects = input.webRtcClient.subjects
 
-  return webRtcSubjects.rtcRestartSubject.pipe(
+  const forceRestart$ = webRtcSubjects.rtcRestartSubject
+
+  const restartActiveConnectionWhenConnectionPasswordChanged$ =
+    input.storageClient.subjects.onPasswordChange.pipe(
+      withLatestFrom(webRtcSubjects.rtcStatusSubject),
+      filter(([_, status]) => status !== 'disconnected')
+    )
+
+  return merge(
+    forceRestart$,
+    restartActiveConnectionWhenConnectionPasswordChanged$
+  ).pipe(
     withLatestFrom(signalingSubjects.wsSourceSubject),
     tap(([, source]) => {
       log.debug(`🕸🔄 [${source}] restarting webRTC...`)


### PR DESCRIPTION
[ABW-691] Should trigger a webRTC restart on a active connection when password is changed

[ABW-691]: https://radixdlt.atlassian.net/browse/ABW-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ