### PR TITLE
chore: update pairing popup connection flow

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -102,6 +102,7 @@ export const Connector = ({
       )
     },
     connect: () => connect(true),
+    getConnectionPassword: storageClient.getConnectionPassword,
     message$: webRtcClient.subjects.rtcIncomingMessageSubject
       .asObservable()
       .pipe(map(parseJSON)),

--- a/src/pairing/components/connection-status.test.tsx
+++ b/src/pairing/components/connection-status.test.tsx
@@ -3,26 +3,6 @@ import '@testing-library/jest-dom'
 
 import { ConnectionStatus } from './connection-status'
 
-test('should render inactive connection state', () => {
-  render(
-    <ConnectionStatus activeConnection={false} onForgetWallet={() => {}} />
-  )
-
-  const connectionStatus: HTMLAnchorElement =
-    screen.getByText(`Connection inactive`)
-
-  expect(connectionStatus).not.toBeEmptyDOMElement()
-})
-
-test('should render active connection state', () => {
-  render(<ConnectionStatus activeConnection={true} onForgetWallet={() => {}} />)
-
-  const connectionStatus: HTMLAnchorElement =
-    screen.getByText(`Connection active`)
-
-  expect(connectionStatus).not.toBeEmptyDOMElement()
-})
-
 test('should render forget wallet button', () => {
   const onForgetWalletSpy = jest.fn()
   render(

--- a/src/pairing/components/connection-status.tsx
+++ b/src/pairing/components/connection-status.tsx
@@ -1,6 +1,5 @@
 import { Box, Button } from '../../components'
 import { PairingHeader } from './pairing-header'
-import { StatusIndicator } from './status-indicator'
 
 type ConnectionStatusProps = {
   activeConnection: boolean
@@ -15,12 +14,7 @@ export const ConnectionStatus = ({
     <PairingHeader header="Radix Wallet Connector">
       This Wallet Connector extension is connected to a Radix Wallet.
     </PairingHeader>
-    <Box mb="3xl" mt="md" flex="row">
-      <StatusIndicator active={activeConnection}>
-        Connection {activeConnection ? 'active' : 'inactive'}
-      </StatusIndicator>
-    </Box>
-    <Box px="medium">
+    <Box px="medium" mt="3xl">
       <Button full onClick={onForgetWallet}>
         Forget this Radix Wallet
       </Button>

--- a/src/pairing/main.tsx
+++ b/src/pairing/main.tsx
@@ -13,7 +13,9 @@ const PairingWrapper = () => {
 
   useEffect(() => {
     if (!connector) return
-    connector.connect()
+    connector.getConnectionPassword().map((password) => {
+      if (!password) connector.connect()
+    })
   }, [connector])
 
   return <Paring />


### PR DESCRIPTION
[ABW-692] Skip webRTC connection on pairing popup if there exists a paired wallet.

[ABW-692]: https://radixdlt.atlassian.net/browse/ABW-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ