### PR TITLE
perf: improve webrtc connection flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "node": ">=18 <19"
   },
   "scripts": {
-    "dev": "DEV_TOOLS=true vite",
+    "start": "DEV_TOOLS=true vite",
+    "start:beta": "DEV_TOOLS=true vite --mode beta",
     "build:dev": "tsc && vite build --mode development",
     "build:beta": "tsc && vite build --mode beta",
     "preview": "vite preview",

--- a/src/chrome/chrome-connector-client.ts
+++ b/src/chrome/chrome-connector-client.ts
@@ -17,6 +17,7 @@ export const ChromeConnectorClient = (logLevel: LogLevelDesc) => {
       storageClient: StorageClient({ id: config.storage.key }),
       generateConnectionPassword: false,
     })
+    connector.connect()
     subscriptions = connector.message$
       .pipe(map((result) => result.map(chromeDAppClient.sendMessage)))
       .subscribe()

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -58,7 +58,6 @@ export const Connector = ({
   }
 
   const init = () => {
-    webRtcClient.connect(true)
     storageClient.getConnectionPassword().map((connectionPassword) => {
       if (connectionPassword) {
         logger.debug(`🔐 setting connectionPassword`)
@@ -102,6 +101,7 @@ export const Connector = ({
       )
     },
     connect: () => connect(true),
+    disconnect: () => connect(false),
     getConnectionPassword: storageClient.getConnectionPassword,
     message$: webRtcClient.subjects.rtcIncomingMessageSubject
       .asObservable()

--- a/src/connector/observables/connection.ts
+++ b/src/connector/observables/connection.ts
@@ -1,4 +1,4 @@
-import { combineLatest, tap } from 'rxjs'
+import { combineLatest, filter, tap } from 'rxjs'
 import { ConnectorSubscriptionsInput } from 'connector/_types'
 
 export const connection = (input: ConnectorSubscriptionsInput) =>
@@ -11,4 +11,12 @@ export const connection = (input: ConnectorSubscriptionsInput) =>
         input.signalingServerClient.subjects.wsConnectSubject.next(false)
       }
     })
+  )
+
+export const killSignalingServerConnection = (
+  input: ConnectorSubscriptionsInput
+) =>
+  input.webRtcClient.subjects.rtcStatusSubject.pipe(
+    filter((status) => status === 'connected'),
+    tap(() => input.signalingServerClient.disconnect())
   )

--- a/src/connector/observables/rtc-restart.ts
+++ b/src/connector/observables/rtc-restart.ts
@@ -16,13 +16,19 @@ export const rtcRestart = (input: ConnectorSubscriptionsInput) => {
 
   return merge(
     forceRestart$,
-    restartActiveConnectionWhenConnectionPasswordChanged$
+    restartActiveConnectionWhenConnectionPasswordChanged$,
+    input.webRtcClient.subjects.rtcConnectSubject
   ).pipe(
-    withLatestFrom(signalingSubjects.wsSourceSubject),
-    tap(([, source]) => {
-      log.debug(`🕸🔄 [${source}] restarting webRTC...`)
-      input.webRtcClient.createPeerConnection()
-      signalingSubjects.wsConnectSubject.next(true)
+    withLatestFrom(
+      signalingSubjects.wsSourceSubject,
+      input.webRtcClient.subjects.rtcConnectSubject
+    ),
+    tap(([, source, shouldConnect]) => {
+      if (shouldConnect) {
+        log.debug(`🕸🔄 [${source}] restarting webRTC...`)
+        input.webRtcClient.createPeerConnection()
+        signalingSubjects.wsConnectSubject.next(true)
+      }
     })
   )
 }

--- a/src/connector/signaling/signaling-server-client.ts
+++ b/src/connector/signaling/signaling-server-client.ts
@@ -117,5 +117,6 @@ export const SignalingServerClient = ({
     destroy,
     subjects,
     connect: (value: boolean) => subjects.wsConnectSubject.next(value),
+    disconnect,
   }
 }

--- a/src/connector/subscriptions.ts
+++ b/src/connector/subscriptions.ts
@@ -1,5 +1,8 @@
 import { Observable, Subscription } from 'rxjs'
-import { connection } from './observables/connection'
+import {
+  connection,
+  killSignalingServerConnection,
+} from './observables/connection'
 import { wsSendMessage } from './observables/ws-send-message'
 import { wsIncomingMessage } from './observables/ws-incoming-message'
 import { rtcRestart } from './observables/rtc-restart'
@@ -23,6 +26,7 @@ export const ConnectorSubscriptions = (input: ConnectorSubscriptionsInput) => {
     storeConnectionPassword,
     regenerateConnectionPassword,
     pairingState,
+    killSignalingServerConnection,
   ]
 
   observables.forEach(

--- a/src/pairing/pairing.tsx
+++ b/src/pairing/pairing.tsx
@@ -22,6 +22,7 @@ export const Paring = () => {
           activeConnection={connectionStatus === 'connected'}
           onForgetWallet={() => {
             connector?.generateConnectionPassword()
+            connector?.connect()
           }}
         />
       )}


### PR DESCRIPTION
Improves the webRTC connection flow and puts less burden on wallet to retry connections. During device pairing phase the connection to signaling server is cut immediately after a data channel has been opened. Reason for this is that wallet is restarting SS after pairing, resulting in resending webRTC session data. If CE delays, a new webRTC negotiation will start between pairing popup and wallet, however it will never complete due to CE shutting down connection to SS. This leaves the wallet in an in-between state which it does not recover from.

<img width="541" alt="image" src="https://user-images.githubusercontent.com/5996605/206900069-9d0cf0e7-a83d-42ea-97d7-3da7829e171f.png">
