### PR TITLE
fix: wait for local offer instead

### DIFF
--- a/src/connector/webrtc/ice-candidate-client.ts
+++ b/src/connector/webrtc/ice-candidate-client.ts
@@ -74,10 +74,15 @@ export const IceCandidateClient = (input: {
     )
   )
 
+  const haveLocalOffer$ = subjects.onSignalingStateChangeSubject.pipe(
+    filter((value) => value === 'have-local-offer')
+  )
+
   const haveRemoteOffer$ = subjects.onSignalingStateChangeSubject.pipe(
     filter((value) => value === 'have-remote-offer')
   )
   const waitForRemoteDescription$ = merge(
+    haveLocalOffer$,
     haveRemoteOffer$,
     subjects.onRemoteAnswerSubject
   )

--- a/src/io-types/types.ts
+++ b/src/io-types/types.ts
@@ -13,7 +13,7 @@ export const SignalingServerMessage = object({
   requestId: string(),
   targetClientId: string(),
   encryptedPayload: string(),
-  source: Sources.optional(), // redundant, to be removed 
+  source: Sources.optional(), // redundant, to be removed
   connectionId: string().optional(), // redundant, to be removed
 })
 


### PR DESCRIPTION
Since the CE is creating the Offer, ice-candidate-client should wait for local offer to be configured.