### PR TITLE
Fix signature response

### DIFF
--- a/src/ledger/wrapper/ledger-wrapper.test.ts
+++ b/src/ledger/wrapper/ledger-wrapper.test.ts
@@ -31,7 +31,10 @@ const createLedgerWrapperWithMockedTransport = (
   })
 }
 
-const getExpectedTransactionSigningExchanges = (instructionCode: string) => [
+const getExpectedTransactionSigningExchanges = (
+  instructionCode: string,
+  finalOutput: string
+) => [
   {
     input: 'aa120000',
     output: '305495ba9000',
@@ -62,19 +65,7 @@ const getExpectedTransactionSigningExchanges = (instructionCode: string) => [
   },
   {
     input: `ac${instructionCode}00002e651702800289ba4758731898e0850fbde5d412c080e4f8b7ea03174cb180d90c0a6669656c645f6e616d65202000`,
-    output:
-      '5ad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa601cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac069000',
-  },
-]
-
-const getExpectedTransacionSignature = (curve: string) => [
-  {
-    curve,
-    derivationPath: `m/44'/1022'/10'/525'/0'/1238'`,
-    publicKey:
-      'cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac06',
-    signature:
-      '5ad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa601',
+    output: finalOutput,
   },
 ]
 
@@ -317,7 +308,8 @@ describe('Ledger Babylon Wrapper', () => {
     it('should sign verbose TX using curve25519', async () => {
       const ledger = createLedgerWrapperWithMockedTransport(
         getExpectedTransactionSigningExchanges(
-          LedgerInstructionCode.SignTxEd255519
+          LedgerInstructionCode.SignTxEd255519,
+          '5ad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa601cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac069000'
         )
       )
 
@@ -330,13 +322,23 @@ describe('Ledger Babylon Wrapper', () => {
 
       if (result.isErr()) throw result.error
 
-      expect(result.value).toEqual(getExpectedTransacionSignature('curve25519'))
+      expect(result.value).toEqual([
+        {
+          curve: 'curve25519',
+          derivationPath: `m/44'/1022'/10'/525'/0'/1238'`,
+          publicKey:
+            'cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac06',
+          signature:
+            '5ad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa601',
+        },
+      ])
     })
 
     it('should sign summary TX using secp256k1', async () => {
       const ledger = createLedgerWrapperWithMockedTransport(
         getExpectedTransactionSigningExchanges(
-          LedgerInstructionCode.SignTxSecp256k1Smart
+          LedgerInstructionCode.SignTxSecp256k1Smart,
+          '5adadad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa601cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac069000'
         )
       )
 
@@ -354,7 +356,16 @@ describe('Ledger Babylon Wrapper', () => {
 
       if (result.isErr()) throw result.error
 
-      expect(result.value).toEqual(getExpectedTransacionSignature('secp256k1'))
+      expect(result.value).toEqual([
+        {
+          curve: 'secp256k1',
+          derivationPath: `m/44'/1022'/10'/525'/0'/1238'`,
+          publicKey:
+            '01cffce054df51fb4072e7faf627e0f64f168fd8811f749d34720ac8da264bac06',
+          signature:
+            '5adadad8cd006761aa698ea77f271c421a7ea9e34da45b4e827d2fce1b5205933b77e852261381cfaa0a8ecfba52622d5c1560462db70df08fc905111e2a9a5fa6',
+        },
+      ])
     })
   })
 })


### PR DESCRIPTION
Unit tests needs fixing... I've tested the build artifact from CI for this OR and it works as expected.

@dawidsowardx @xstelea please prefer using `Buffer`, **always**, for data, you are using `string` which is error prone and semantically wrong. This leads to all lengths and offset being measured in 2x that of bytes. Using strings also can result in bad data, accidentally adding non hex chars and then sending those over the wire, so they are also less safe.

When working with data, always use the most precise type, which for everything relating to data is `buffer`. Signatures/PublicKeys/PrivateKeys are almost always represented as data: `buffer`, the internal representation ought to be that. Whatever we do before sending those values from CE to Wallet is then a matter of choice of **encoding** the values, where we typically default to hex encoding.

But to take this one step further - which we should! - you should really implement types for `Secp256k1PublicKey` and `Curve25519PublicKey` which not only holds the value as `buffer` but which constructor also validates the keys! Remember, a public key is a **point in a curve**, represented in affine coordinates as `(x, y)` tuple. Meaning that not any 64. bytes sequence is a valid public key. CE should be made aware of this and validate both keys from Wallet but more importantly keys from Ledger! This will allow us to capture bugs as early as possible. Do do that by using e.g. `elliptic.js`'s constructor of the public key type and ensure the constructor validates the key - `keyFromPublic` method does that, (see it calls [_importPublic](https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/dist/elliptic.js#L2503)). So do that for both curves. 

Analogously also create types `ECDSASignature` and `EdDSASignature` (for `secp256k1` and `Curve25519` respectivley), and given a response from CE perform validation of the signature! using `verify` function on elliptic public key (for respective curve). So you will need to:

```javascript
const hash = blake2b(signTXReqFromWallet.compiledTXIntent)
const publicKeyWithSignArray = responsesFromLedger.map { (pkSigTuple, index) => {
   const curve = methodThatMatchesResponseWithRequestGivenIndex(index, signTXReqFromWallet).curve
   const publicKey = publicKeyFrom(pkSigTuple.publicKey, curve=curve)
   const signature = signatureFrom(pkSigTuple.signature, curve=curve)
   if publicKey.verify(signature, hash) {
      return ok({ publicKey, signature }) // all good
   } else {
      return err('Invalid signature')
   }
}} 
```