### PR TITLE
fix: destruct of undefined value ledger-tab-watcher.ts

### DIFF
--- a/src/chrome/background/ledger-tab-watcher.ts
+++ b/src/chrome/background/ledger-tab-watcher.ts
@@ -18,7 +18,7 @@ export const LedgerTabWatcher = () => ({
       return
     }
 
-    const { tabId, messageId } = watchedTab.value
+    const { tabId, messageId } = watchedTab.value {}
 
     if (!messageId || !tabId || justRemovedTabId !== tabId) {
       return

--- a/src/chrome/background/ledger-tab-watcher.ts
+++ b/src/chrome/background/ledger-tab-watcher.ts
@@ -18,7 +18,7 @@ export const LedgerTabWatcher = () => ({
       return
     }
 
-    const { tabId, messageId } = watchedTab.value {}
+    const { tabId, messageId } = watchedTab.value || {}
 
     if (!messageId || !tabId || justRemovedTabId !== tabId) {
       return


### PR DESCRIPTION
When the local storage item does not exist, destruction yields error.

`http://localhost:5174/src/chrome/background/ledger-tab-watcher.ts`

```
Uncaught (in promise) TypeError: Cannot destructure property 'tabId' of 'watchedTab.value' as it is undefined.
```