### PR TITLE
feat: send extension status message on init

### DIFF
--- a/src/chrome/content-script/content-script.ts
+++ b/src/chrome/content-script/content-script.ts
@@ -6,6 +6,7 @@ import { ConfirmationMessageError, Message } from '../messages/_types'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { logger } from 'utils/logger'
 import { MessageLifeCycleEvent } from 'chrome/dapp/_types'
+import { getConnectionPassword } from 'chrome/helpers/get-connection-password'
 
 const chromeDAppClient = ChromeDAppClient()
 
@@ -57,3 +58,7 @@ chrome.storage.onChanged.addListener(
       )
   },
 )
+
+getConnectionPassword().map((connectionPassword) => {
+  sendMessageToDapp(createMessage.extensionStatus(!!connectionPassword))
+})


### PR DESCRIPTION
alternative would be to inject content script at document start, but that was previously changed (probably for some good reason) so I don't want to mess with that