### PR TITLE
feat: allow iframe communication

### DIFF
--- a/src/chrome/content-script/content-script.ts
+++ b/src/chrome/content-script/content-script.ts
@@ -21,10 +21,15 @@ const sendMessageToDapp = (
 }
 
 const sendMessageEventToDapp = (
-  interactionId: string,
+  data: { interactionId: string; metadata: { origin: string } },
   eventType: MessageLifeCycleEvent,
 ): ResultAsync<undefined, ConfirmationMessageError['error']> => {
-  const result = chromeDAppClient.sendMessageEvent(interactionId, eventType)
+  if (window.location.origin !== data.metadata.origin) return okAsync(undefined)
+
+  const result = chromeDAppClient.sendMessageEvent(
+    data.interactionId,
+    eventType,
+  )
   return result.isErr()
     ? errAsync({ reason: 'unableToSendMessageEventToDapp' })
     : okAsync(undefined)

--- a/src/chrome/messages/_types.ts
+++ b/src/chrome/messages/_types.ts
@@ -92,7 +92,10 @@ export type Messages = {
 
   [messageDiscriminator.sendMessageEventToDapp]: MessageBuilder<
     MessageDiscriminator['sendMessageEventToDapp'],
-    { messageEvent: MessageLifeCycleEvent; interactionId: string }
+    {
+      messageEvent: MessageLifeCycleEvent
+      data: { interactionId: string; metadata: { origin: string } }
+    }
   >
   [messageDiscriminator.log]: MessageBuilder<
     MessageDiscriminator['log'],

--- a/src/chrome/messages/create-message.ts
+++ b/src/chrome/messages/create-message.ts
@@ -180,12 +180,12 @@ export const createMessage = {
   sendMessageEventToDapp: (
     source: MessageSource,
     messageEvent: MessageLifeCycleEvent,
-    interactionId: string,
+    data: { interactionId: string; metadata: { origin: string } },
   ): Messages['sendMessageEventToDapp'] => ({
     source,
     discriminator: 'sendMessageEventToDapp',
     messageId: crypto.randomUUID(),
     messageEvent,
-    interactionId,
+    data,
   }),
 } as const

--- a/src/chrome/messages/message-client.spec.ts
+++ b/src/chrome/messages/message-client.spec.ts
@@ -3,18 +3,18 @@ import { errAsync, okAsync } from 'neverthrow'
 import { filter, firstValueFrom } from 'rxjs'
 import { Logger } from 'tslog'
 import { BackgroundMessageHandler } from '../background/message-handler'
-import { ContentScriptMessageHandler } from '../content-script/message-handler'
 import { OffscreenMessageHandler } from '../offscreen/message-handler'
 import { createMessage } from './create-message'
 import { MessageClient } from './message-client'
 import { MessageSubjects } from './subjects'
+import { ContentScriptMessageHandler } from 'chrome/content-script/message-handler'
 
 const logger = new Logger()
 
 const dAppRequestQueue = { add: () => okAsync(undefined) } as any
 
 const createTestHelper = ({
-  messageRouter = MessagesRouter({ logger }),
+  messageRouter = MessagesRouter(),
   messageClientSubjects = MessageSubjects(),
   backgroundMessageClient = MessageClient(
     BackgroundMessageHandler({
@@ -139,7 +139,10 @@ describe('message client', () => {
   // so it has to proxy the message through background message handler
   it('should send wallet response to dApp', async () => {
     const testHelper = createTestHelper({})
-    testHelper.messageRouter.add(1, '456', { origin: 'origin', networkId: 1 })
+    testHelper.messageRouter.add(1, '456', {
+      origin: 'http://localhost',
+      networkId: 1,
+    })
     testHelper.mockIncomingWalletMessage({ interactionId: '456' }, 1)
 
     await Promise.all([

--- a/src/chrome/offscreen/offscreen.ts
+++ b/src/chrome/offscreen/offscreen.ts
@@ -20,7 +20,7 @@ utilsLogger.attachTransport((logObj) => {
 })
 const logger = utilsLogger.getSubLogger({ name: 'offscreen' })
 
-const messageRouter = MessagesRouter({ logger })
+const messageRouter = MessagesRouter()
 
 const connectorClient = ConnectorClient({
   source: 'extension',
@@ -40,15 +40,15 @@ const dAppRequestQueue = Queue<any>({
       .sendMessage(job.data, { timeout: config.webRTC.confirmationTimeout })
       .map(() =>
         messageRouter
-          .getTabId(job.data.interactionId)
-          .andThen((tabId) =>
+          .getByInteractionId(job.data.interactionId)
+          .andThen((metadata) =>
             messageClient.sendMessageAndWaitForConfirmation(
               createMessage.sendMessageEventToDapp(
                 'offScreen',
                 'receivedByWallet',
-                job.data.interactionId,
+                { interactionId: job.data.interactionId, metadata },
               ),
-              tabId,
+              metadata.tabId,
             ),
           ),
       )

--- a/src/message-router.ts
+++ b/src/message-router.ts
@@ -1,13 +1,11 @@
 import { errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
-import { AppLogger } from 'utils/logger'
 
 export type MessagesRouter = ReturnType<typeof MessagesRouter>
 
-export const MessagesRouter = ({ logger }: { logger: AppLogger }) => {
-  const store = new Map<
-    string,
-    { tabId: number; origin: string; networkId: number }
-  >()
+type Item = { tabId: number; origin: string; networkId: number }
+
+export const MessagesRouter = () => {
+  const store = new Map<string, Item>()
 
   const add = (
     tabId: number,
@@ -19,16 +17,18 @@ export const MessagesRouter = ({ logger }: { logger: AppLogger }) => {
     return ok(undefined)
   }
 
-  const getTabId = (interactionId: string): ResultAsync<number, Error> => {
+  const getByInteractionId = (
+    interactionId: string,
+  ): ResultAsync<Item, Error> => {
     const values = store.get(interactionId)
-    return values ? okAsync(values.tabId) : errAsync(new Error('No tab found'))
+    return values ? okAsync(values) : errAsync(new Error('Item not found'))
   }
 
   const getNetworkId = (interactionId: string): ResultAsync<number, Error> => {
     const values = store.get(interactionId)
     return values
       ? okAsync(values.networkId)
-      : errAsync(new Error('No tab found'))
+      : errAsync(new Error('Item not found'))
   }
 
   const getInteractionIdsByTabId = (
@@ -56,7 +56,7 @@ export const MessagesRouter = ({ logger }: { logger: AppLogger }) => {
 
   return {
     add,
-    getTabId,
+    getByInteractionId,
     store,
     getNetworkId,
     getInteractionIdsByTabId,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,7 @@ const manifest = defineManifest(async () => {
         matches,
         js: ['src/chrome/content-script/content-script.ts'],
         run_at: 'document_idle',
+        all_frames: true,
       },
     ],
     options_page: 'src/options/index.html',


### PR DESCRIPTION
This PR includes code to enable embedded iframes to interact with the connector extension. 

**Considerations:** 
- Requests should not be interceptable by other frames within the same browser tab
- Requester origin is the frame origin. e.g. an embedded iframe with a different origin should not have the same origin as the root frame. 