### PR TITLE
ci: Add beta version on merge to develop [DO-2188]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           sed -i "s/\${EXTENSION_ID}/$GOOGLE_EXTENSION_ID/g" release.config.cjs
           sed -i "s/\${TARGET}/$TARGET_RELEASE/g" release.config.cjs
-          sed -i "s/\radix-connector_v${nextRelease.version}.zip/radix-connector_v${nextRelease.version}-BETA.zip/g" release.config.cjs
+          sed -i "s/\}.zip/}-BETA.zip/g" release.config.cjs
           npx semantic-release --verifyConditions | tee out
           echo "RELEASE_VERSION=$(grep 'Created tag ' out | awk -F 'Created tag ' '{print $2}')" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,12 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ env.GH_CLIENT_SECRET }}
           GOOGLE_REFRESH_TOKEN: ${{ env.GH_REFRESH_TOKEN }}
           GOOGLE_EXTENSION_ID: ${{ env.GH_EXTENSION_ID }}
-          TARGET_RELEASE: trustedTesters
+          TARGET_RELEASE: draft
         run: |
+          sed -i "s/    name:.*/    name: 'Radix Wallet Connector - BETA'/" vite.config.ts
+          sed -i -E '/^ *description:.*$/ {N; s/.*/    description: '"'"'THIS EXTENSION IS FOR BETA TESTING'"'"',/}' vite.config.ts
           sed -i "s/\${EXTENSION_ID}/$GOOGLE_EXTENSION_ID/g" release.config.cjs
           sed -i "s/\${TARGET}/$TARGET_RELEASE/g" release.config.cjs
-          sed -i "s/\}.zip/}-BETA.zip/g" release.config.cjs
           npx semantic-release --verifyConditions | tee out
           echo "RELEASE_VERSION=$(grep 'Created tag ' out | awk -F 'Created tag ' '{print $2}')" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,15 @@ jobs:
           parse_json: true
 
       - name: Github PreRelease
-        if: startsWith(github.ref_name, 'release/') || github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop'
         env:
           VITE_GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           GOOGLE_CLIENT_ID: ${{ env.GH_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ env.GH_CLIENT_SECRET }}
           GOOGLE_REFRESH_TOKEN: ${{ env.GH_REFRESH_TOKEN }}
-          GOOGLE_EXTENSION_ID: ${{ env.GH_EXTENSION_ID }}
-          TARGET_RELEASE: draft
+          GOOGLE_EXTENSION_ID: ${{ env.GH_BETA_EXTENSION_ID }}
+          TARGET_RELEASE: trustedTesters
         run: |
           sed -i "s/    name:.*/    name: 'Radix Wallet Connector - BETA'/" vite.config.ts
           sed -i -E '/^ *description:.*$/ {N; s/.*/    description: '"'"'THIS EXTENSION IS FOR BETA TESTING'"'"',/}' vite.config.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,11 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ env.GH_CLIENT_SECRET }}
           GOOGLE_REFRESH_TOKEN: ${{ env.GH_REFRESH_TOKEN }}
           GOOGLE_EXTENSION_ID: ${{ env.GH_EXTENSION_ID }}
-          TARGET_RELEASE: local
+          TARGET_RELEASE: trustedTesters
         run: |
           sed -i "s/\${EXTENSION_ID}/$GOOGLE_EXTENSION_ID/g" release.config.cjs
           sed -i "s/\${TARGET}/$TARGET_RELEASE/g" release.config.cjs
+          sed -i "s/\radix-connector_v${nextRelease.version}.zip/radix-connector_v${nextRelease.version}-BETA.zip/g" release.config.cjs
           npx semantic-release --verifyConditions | tee out
           echo "RELEASE_VERSION=$(grep 'Created tag ' out | awk -F 'Created tag ' '{print $2}')" >> $GITHUB_ENV
 


### PR DESCRIPTION
Changes: 
   - When merge to develop, uploads the BETA extension to the webstore, but skips the publishing step. 